### PR TITLE
feat: Implement Splash Screen and improve logout

### DIFF
--- a/app/src/main/java/com/example/atonce_admin/di/ViewModelModule.kt
+++ b/app/src/main/java/com/example/atonce_admin/di/ViewModelModule.kt
@@ -3,6 +3,7 @@ package com.example.atonce_admin.di
 import StatusOrderViewModel
 import com.example.atonce_admin.presentation.home.viewModel.HomeViewModel
 import com.example.atonce_admin.presentation.login.viemodel.LoginViewModel
+import com.example.atonce_admin.presentation.splash.veiwModel.SplashViewModel
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
@@ -11,10 +12,14 @@ val viewModelModule = module {
         StatusOrderViewModel(get())
     }
     viewModel {
-        HomeViewModel(get() , get())
+        HomeViewModel(get() , get() , get())
     }
 
     viewModel {
         LoginViewModel(get(),get())
+    }
+
+    viewModel {
+        SplashViewModel(get())
     }
 }

--- a/app/src/main/java/com/example/atonce_admin/presentation/common/component/LogoIcon.kt
+++ b/app/src/main/java/com/example/atonce_admin/presentation/common/component/LogoIcon.kt
@@ -1,4 +1,5 @@
-package com.example.atonce_admin.presentation.login.components
+
+package com.example.atonce_admin.presentation.common.component
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box

--- a/app/src/main/java/com/example/atonce_admin/presentation/common/navigation/NavHost.kt
+++ b/app/src/main/java/com/example/atonce_admin/presentation/common/navigation/NavHost.kt
@@ -12,6 +12,7 @@ import com.example.atonce_admin.presentation.orders.OrdersScreen
 import com.example.atonce_admin.presentation.home.view.HomeWithDrawerScreen
 import com.example.atonce_admin.presentation.login.LoginScreen
 import com.example.atonce_admin.presentation.profile.ProfileScreen
+import com.example.atonce_admin.presentation.splash.view.SplashScreen
 import com.example.atonce_admin.presentation.stateOrders.view.StateOrders
 import com.example.atonce_admin.presentation.users.UsersScreen
 import com.google.gson.Gson
@@ -24,8 +25,25 @@ fun SetUpNavHost(
 ) {
     NavHost(
         navController = navController,
-        startDestination = ScreenRoute.LoginScreen
+        startDestination = ScreenRoute.SplashScreen
     ) {
+
+        composable<ScreenRoute.SplashScreen> {
+            SplashScreen{
+                if (it) {
+                    navController.navigate(ScreenRoute.HomeScreen) {
+                        popUpTo(0) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                } else {
+                    navController.navigate(ScreenRoute.LoginScreen) {
+                        popUpTo(0) { inclusive = true }
+                        launchSingleTop = true
+                    }
+                }
+            }
+        }
+
         composable<ScreenRoute.LoginScreen> {
             LoginScreen(snackbarHostState=snackbarHostState){
                 navController.navigate(ScreenRoute.HomeScreen) {

--- a/app/src/main/java/com/example/atonce_admin/presentation/home/view/Home.kt
+++ b/app/src/main/java/com/example/atonce_admin/presentation/home/view/Home.kt
@@ -188,16 +188,17 @@ fun HomeWithDrawerScreen(
 
                     },
                     onLogout = {
-                        onLogout()
                         scope.launch { drawerState.close() }
+                        viewModel.logout()
+                        onLogout()
                     },
                     onProfileClicked = {
-                        onProfileClicked()
                         scope.launch { drawerState.close() }
+                        onProfileClicked()
                     },
                     onCustomerClicked = {
-                        onCustomerClicked()
                         scope.launch { drawerState.close() }
+                        onCustomerClicked()
                     }
                 )
             }

--- a/app/src/main/java/com/example/atonce_admin/presentation/home/viewModel/HomeViewModel.kt
+++ b/app/src/main/java/com/example/atonce_admin/presentation/home/viewModel/HomeViewModel.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.viewModelScope
 import com.example.atonce_admin.data.Response
 import com.example.atonce_admin.domain.entity.ControlPanelEntity
 import com.example.atonce_admin.domain.entity.UserEntity
+import com.example.atonce_admin.domain.usecase.FreeUserDataUseCase
 import com.example.atonce_admin.domain.usecase.GetControlPanelDataUseCase
 import com.example.atonce_admin.domain.usecase.GetUserDataUseCase
 import kotlinx.coroutines.Dispatchers
@@ -15,7 +16,8 @@ import kotlinx.coroutines.launch
 
 class HomeViewModel(
     private val getControlPanelDataUseCase: GetControlPanelDataUseCase
-    ,private val getUserDataUseCase: GetUserDataUseCase
+    ,private val getUserDataUseCase: GetUserDataUseCase,
+    private val logoutUseCase: FreeUserDataUseCase
 ) : ViewModel() {
 
     private var _controlPanelDataState = MutableStateFlow<Response<ControlPanelEntity>>(Response.Loading)
@@ -37,7 +39,10 @@ class HomeViewModel(
                     _controlPanelDataState.value = Response.Success(it)
                 }
         }
+    }
 
+    fun logout(){
+        logoutUseCase()
     }
 
 

--- a/app/src/main/java/com/example/atonce_admin/presentation/login/LoginScreen.kt
+++ b/app/src/main/java/com/example/atonce_admin/presentation/login/LoginScreen.kt
@@ -26,7 +26,7 @@ import com.example.atonce_admin.presentation.common.theme.BoldFont
 import com.example.atonce_admin.presentation.common.theme.PrimaryColor
 import com.example.atonce_admin.presentation.common.theme.RegularFont
 import com.example.atonce_admin.presentation.login.components.CustomTextField
-import com.example.atonce_admin.presentation.login.components.LogoIcon
+import com.example.atonce_admin.presentation.common.component.LogoIcon
 import com.example.atonce_admin.presentation.login.components.PrimaryButton
 import com.example.atonce_admin.presentation.login.viemodel.LoginViewModel
 import org.koin.androidx.compose.koinViewModel

--- a/app/src/main/java/com/example/atonce_admin/presentation/splash/veiwModel/SplashViewModel.kt
+++ b/app/src/main/java/com/example/atonce_admin/presentation/splash/veiwModel/SplashViewModel.kt
@@ -1,0 +1,30 @@
+package com.example.atonce_admin.presentation.splash.veiwModel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.example.atonce_admin.data.Response
+import com.example.atonce_admin.domain.usecase.IsLoggedInUseCase
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+
+class SplashViewModel(
+    private val isLoggedInUseCase: IsLoggedInUseCase
+) : ViewModel() {
+
+    private var _isLoggedIn = MutableStateFlow<Response<Boolean>>(Response.Loading)
+    val isLoggedIn = _isLoggedIn.asStateFlow()
+
+    fun isLoggedIn(interval : Long) {
+        viewModelScope.launch(Dispatchers.IO){
+            delay(interval)
+            withContext(Dispatchers.Main){
+                _isLoggedIn.value = Response.Success(isLoggedInUseCase())
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/example/atonce_admin/presentation/splash/view/SplashScreen.kt
+++ b/app/src/main/java/com/example/atonce_admin/presentation/splash/view/SplashScreen.kt
@@ -1,0 +1,55 @@
+package com.example.atonce_admin.presentation.splash.view
+
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.example.atonce_admin.data.Response
+import com.example.atonce_admin.presentation.common.component.LogoIcon
+import com.example.atonce_admin.presentation.splash.veiwModel.SplashViewModel
+import org.koin.androidx.compose.koinViewModel
+
+
+@Composable
+fun SplashScreen(
+    viewModel: SplashViewModel = koinViewModel(),
+    onSplashFinished: (Boolean) -> Unit
+) {
+
+    val isLoggedIn = viewModel.isLoggedIn.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.isLoggedIn(2000)
+    }
+    SplashContent()
+
+    when (isLoggedIn.value) {
+        is Response.Error -> {
+
+        }
+        Response.Loading -> {
+
+        }
+        is Response.Success-> {
+            val data = (isLoggedIn.value as Response.Success).data
+            onSplashFinished(data)
+        }
+    }
+}
+
+
+@Preview
+@Composable
+fun SplashContent() {
+    Box(
+        modifier = Modifier
+            .fillMaxSize()
+        , contentAlignment = Alignment.Center
+    ){
+        LogoIcon()
+    }
+}


### PR DESCRIPTION
This commit introduces a splash screen that checks if the user is logged in and navigates accordingly. It also enhances the logout functionality.

**Splash Screen:**
- Added `SplashScreen.kt` which displays a logo for a short duration.
- Created `SplashViewModel.kt` to handle the logic for checking login status using `IsLoggedInUseCase`.
- After a delay, the ViewModel determines if the user is logged in:
    - If logged in, navigates to `HomeScreen`.
    - If not logged in, navigates to `LoginScreen`.
- `NavHost.kt` updated to set `SplashScreen` as the `startDestination`.
- `LogoIcon.kt` moved from `presentation.login.components` to `presentation.common.component` to be reusable.
- `ViewModelModule.kt` updated to provide `SplashViewModel`.

**Logout Enhancement:**
- In `HomeViewModel.kt`, a `logout()` function was added which calls `FreeUserDataUseCase` to clear user data.
- In `Home.kt`, the `onLogout` lambda in `HomeWithDrawerScreen` now:
    - Closes the drawer.
    - Calls `viewModel.logout()` to clear user data.
    - Then triggers the `onLogout` navigation action.

**Navigation:**
- `NavHost.kt`:
    - Updated navigation from `SplashScreen` to either `HomeScreen` or `LoginScreen` to use `popUpTo(0) { inclusive = true }` and `launchSingleTop = true` to clear the backstack and prevent multiple instances.